### PR TITLE
Support NodeJS 12.x

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -6,16 +6,20 @@ on:
 
 jobs:
   lint-build-test:
+    strategy:
+      matrix:
+        node: ['12.x', '14.x']
     env:
       COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     name: Lint, Build, Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        name: Checkout code
       - name: Set up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: ${{ matrix.node }}
       - name: Install Node.js dependencies
         uses: bahmutov/npm-install@v1
       - name: Run lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [O.3.3] - 2021-03-02
+
+### Added
+
+- Node strategy matrix for 12.x and 14.x Lint, Build, Test jobs
+
+### Changed
+
+- Build for ES2018 instead of ES2020
+- Use setup-node@2 in actions
+
+## [0.3.2] - 2021-02-26
+
+### Changed
+
+- Validatorjs types in production bundle
+
 ## [0.3.1] - 2021-02-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ArrowSphere nodejs-api-client package
 
 [![npm version](https://badgen.net/npm/v/@arrowsphere/api-client)](https://www.npmjs.com/package/@arrowsphere/api-client)
-[![node version](https://badgen.net/badge/node/>=%2014.15.4/green?icon=terminal)](https://badgen.net/badge/node/>=%2014.15.4/green?icon=terminal)
+[![node version](https://badgen.net/badge/node/>=%2012.21.0/green?icon=terminal)](https://badgen.net/badge/node/>=%2012.21.0/green?icon=terminal)
 [![Lint, Build, Test](https://github.com/ArrowSphere/nodejs-api-client/workflows/Lint,%20Build,%20Test/badge.svg)](https://github.com/ArrowSphere/nodejs-api-client/actions?query=workflow%3A%22Lint%2C+Build%2C+Test%22)
 [![Coverage Status](https://coveralls.io/repos/github/ArrowSphere/nodejs-api-client/badge.svg?branch=main)](https://coveralls.io/github/ArrowSphere/nodejs-api-client?branch=main)
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/ArrowSphere/nodejs-api-client.git"
   },
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Node.js client for ArrowSphere's public API",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
   "compileOnSave": true,
   "compilerOptions": {
     // Output options
-    "lib": ["ES2020"],
-    "target": "ES2020",
+    "lib": ["ES2018"],
+    "target": "ES2018",
     "sourceMap": true,
     "outDir": "./build",
 


### PR DESCRIPTION
Build for ES2018 instead of ES2020