### PR TITLE
Feat add ClientsRegistry

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:fix": "eslint ./{src,tests}/**/*.ts --fix && prettier --write ./{src,tests}/**/*.ts",
     "prepare": "npm run clean && npm run build",
     "test": "mocha -r ts-node/register \"tests/**/*.ts\"",
+    "test:one": "mocha -r ts-node/register",
     "test:watch": "mocha --watch -r ts-node/register \"tests/**/*.ts\"",
     "test:coverage": "nyc --check-coverage npm run test",
     "test:coverage:report": "nyc report --reporter=text-lcov | coveralls"

--- a/src/AbstractHttpClient.ts
+++ b/src/AbstractHttpClient.ts
@@ -9,6 +9,8 @@ export enum HttpClientSecurity {
   API_KEY = 'apikey',
 }
 
+export type Headers = Record<string, string>;
+
 export abstract class AbstractHttpClient {
   /**
    * Base path for HTTP calls
@@ -26,6 +28,10 @@ export abstract class AbstractHttpClient {
    * ArrowSphere API URL
    */
   protected url = '';
+  /**
+   * Defines header information for http requests
+   */
+  protected headers: Headers = {};
   /**
    * Http Exceptions Handlers
    */
@@ -51,6 +57,31 @@ export abstract class AbstractHttpClient {
 
   public setSecurity(security: HttpClientSecurity): this {
     this.security = security;
+
+    return this;
+  }
+
+  /**
+   * Warning: can remove useful headers, prefer use mergeHeaders()
+   * @param headers
+   */
+  public setHeaders(headers: Record<string, string>): this {
+    this.headers = headers;
+
+    return this;
+  }
+
+  /**
+   * Will merge existing headers with those in parameters.
+   * If There is key equality, the header passed as parameter has priority.
+   * @param headers
+   */
+  public mergeHeaders(headers: Record<string, string>): this {
+    const mergedHeaders: Record<string, string> = {
+      ...this.headers,
+      ...headers,
+    };
+    this.setHeaders(mergedHeaders);
 
     return this;
   }

--- a/src/abstractGraphQLClient.ts
+++ b/src/abstractGraphQLClient.ts
@@ -9,22 +9,22 @@ import { AbstractHttpClient } from './AbstractHttpClient';
 export type GraphQLResponseTypes = GetProductsType;
 
 export abstract class AbstractGraphQLClient extends AbstractHttpClient {
-  protected client!: GraphQLClient;
+  /**
+   * Must not be called directly.
+   * Use getClientInstance() to access it.
+   * @protected
+   */
+  protected graphQLClient!: GraphQLClient;
 
   protected optionsHeader?: Dom.RequestInit['headers'];
 
   protected options: Options = {};
 
-  private getClient() {
-    this.client = new GraphQLClient(this.generateUrl());
-
-    return this;
-  }
-
-  public setOptionsHeader(options: Dom.RequestInit['headers']): this {
-    this.optionsHeader = options;
-
-    return this;
+  private getClientInstance(): GraphQLClient {
+    return (
+      this.graphQLClient ??
+      (this.graphQLClient = new GraphQLClient(this.generateUrl()))
+    );
   }
 
   public setOptions(options: Options): this {
@@ -36,15 +36,16 @@ export abstract class AbstractGraphQLClient extends AbstractHttpClient {
   protected async post<GraphQLResponseTypes>(
     query: string,
   ): Promise<GraphQLResponseTypes> {
-    this.getClient().client.setHeaders({
+    const headers: Record<string, string> = {
       authorization: this.token,
-      ...this.optionsHeader,
-    });
+      ...this.headers,
+    };
+    this.getClientInstance().setHeaders(headers);
 
-    return await this.client.request<GraphQLResponseTypes>(query);
+    return await this.getClientInstance().request<GraphQLResponseTypes>(query);
   }
 
-  protected generateUrl(): string {
+  private generateUrl(): string {
     const url = new URL(
       `${
         this.options.isAdmin ? path.join('admin', this.basePath) : this.basePath

--- a/src/abstractRestfulClient.ts
+++ b/src/abstractRestfulClient.ts
@@ -3,7 +3,11 @@ import querystring from 'querystring';
 import path from 'path';
 import { AxiosSingleton } from './axiosSingleton';
 import { AxiosInstance, AxiosResponse } from 'axios';
-import { AbstractHttpClient, HttpClientSecurity } from './AbstractHttpClient';
+import {
+  AbstractHttpClient,
+  Headers,
+  HttpClientSecurity,
+} from './AbstractHttpClient';
 
 /**
  * Lists of available query parameters for the API call
@@ -38,8 +42,6 @@ export type Parameters = Record<
   string,
   string | string[] | number | number[] | boolean | null | undefined
 >;
-
-export type Headers = Record<string, string>;
 
 export type Payload = Record<string, unknown> | Array<Payload>;
 
@@ -82,11 +84,6 @@ export abstract class AbstractRestfulClient extends AbstractHttpClient {
    * Defines whether the pagination options are camel cased or not
    */
   protected isCamelPagination = false;
-
-  /**
-   * Defines header information for axios call
-   */
-  protected headers: Headers = {};
 
   /**
    * AbstractClient constructor.
@@ -138,17 +135,6 @@ export abstract class AbstractRestfulClient extends AbstractHttpClient {
    */
   public setPage(page: number): this {
     this.page = page;
-
-    return this;
-  }
-
-  /**
-   * Sets Header Information
-   * @param headers - Header axios information
-   * @returns AbstractRestfulClient
-   */
-  public setHeaders(headers: Record<string, string>): this {
-    this.headers = headers;
 
     return this;
   }

--- a/src/clientsRegistry.ts
+++ b/src/clientsRegistry.ts
@@ -1,0 +1,280 @@
+import { CheckDomainClient, WhoAmIClient } from './general';
+import { LicensesClient } from './licenses';
+import { SubscriptionsClient } from './subscriptions';
+import { CustomersClient } from './customers';
+import { OrdersClient } from './orders';
+import { ContactClient } from './contact';
+import { CampaignClient } from './campaign';
+import { ConsumptionClient } from './consumption';
+import { StandardsClient } from './security';
+import { RegisterClient } from './security';
+import { CartClient } from './cart';
+import { SupportCenterClient } from './supportCenter';
+import { CatalogClient, CatalogGraphQLClient } from './catalog';
+import { UserClient } from './user';
+import PublicApiClient from './publicApiClient';
+import { PublicGraphQLClient } from './publicGraphQLClient';
+
+/**
+ * Allow to have single instance of each client.
+ */
+export class ClientsRegistry {
+  // common properties
+  private headers: Record<string, string> = {};
+  private legacyHeaders: Record<string, string> = {};
+
+  // rest instances
+  private customerClientInstance: CustomersClient | undefined;
+  private whoAmIClientInstance: WhoAmIClient | undefined;
+  private licensesClientInstance: LicensesClient | undefined;
+  private checkDomainClientInstance: CheckDomainClient | undefined;
+  private subscriptionsClientInstance: SubscriptionsClient | undefined;
+  private ordersClientInstance: OrdersClient | undefined;
+  private contactClientInstance: ContactClient | undefined;
+  private campaignClientInstance: CampaignClient | undefined;
+  private consumptionClientInstance: ConsumptionClient | undefined;
+  private securityStandardsClientInstance: StandardsClient | undefined;
+  private securityRegisterClientInstance: RegisterClient | undefined;
+  private cartClientInstance: CartClient | undefined;
+  private supportCenterClientInstance: SupportCenterClient | undefined;
+  private catalogClientInstance: CatalogClient | undefined;
+  private userClientInstance: UserClient | undefined;
+
+  // gql instances
+  private gqlCatalogClientInstance: CatalogGraphQLClient | undefined;
+
+  constructor(
+    private readonly publicApiClient: PublicApiClient,
+    private readonly gqlPublicApiClient: PublicGraphQLClient,
+  ) {}
+
+  public static create(
+    publicApiClient: PublicApiClient,
+    gqlPublicApiClient: PublicGraphQLClient,
+  ): ClientsRegistry {
+    return new ClientsRegistry(publicApiClient, gqlPublicApiClient);
+  }
+
+  public getCustomersClientInstance(): CustomersClient {
+    if (!this.customerClientInstance) {
+      this.customerClientInstance = this.publicApiClient
+        .getCustomersClient()
+        .mergeHeaders(this.headers);
+    }
+
+    return this.customerClientInstance;
+  }
+
+  /**
+   * Creates a new {@link WhoAmIClient} instance and returns it
+   * @returns {@link WhoAmIClient}
+   */
+  public getWhoamiClientInstance(): WhoAmIClient {
+    if (!this.whoAmIClientInstance) {
+      this.whoAmIClientInstance = this.publicApiClient
+        .getWhoamiClient()
+        .mergeHeaders(this.headers);
+    }
+
+    return this.whoAmIClientInstance;
+  }
+
+  /**
+   * Creates a new {@link LicensesClient} instance and returns it
+   * @returns {@link LicensesClient}
+   */
+  public getLicensesClientInstance(): LicensesClient {
+    if (!this.licensesClientInstance) {
+      this.licensesClientInstance = this.publicApiClient
+        .getLicensesClient()
+        .mergeHeaders(this.legacyHeaders);
+    }
+
+    return this.licensesClientInstance;
+  }
+
+  /**
+   * Creates a new {@link CheckDomainClient} instance and returns it
+   * @returns {@link CheckDomainClient}
+   */
+  public getCheckDomainClientInstance(): CheckDomainClient {
+    if (!this.checkDomainClientInstance) {
+      this.checkDomainClientInstance = this.publicApiClient
+        .getCheckDomainClient()
+        .mergeHeaders(this.headers);
+    }
+
+    return this.checkDomainClientInstance;
+  }
+
+  /**
+   * Creates a new {@link SubscriptionsClient} instance and returns it
+   * @returns {@link SubscriptionsClient}
+   */
+  public getSubscriptionsClientInstance(): SubscriptionsClient {
+    if (!this.subscriptionsClientInstance) {
+      this.subscriptionsClientInstance = this.publicApiClient
+        .getSubscriptionsClient()
+        .mergeHeaders(this.headers);
+    }
+
+    return this.subscriptionsClientInstance;
+  }
+
+  /**
+   * Creates a new {@link OrdersClient} instance and returns it
+   * @returns {@link OrdersClient}
+   */
+  public getOrdersClientInstance(): OrdersClient {
+    if (!this.ordersClientInstance) {
+      this.ordersClientInstance = this.publicApiClient
+        .getOrdersClient()
+        .mergeHeaders(this.headers);
+    }
+
+    return this.ordersClientInstance;
+  }
+
+  /**
+   * Creates a new {@link ContactClient} instance and returns it
+   * @returns {@link ContactClient}
+   */
+  public getContactClientInstance(): ContactClient {
+    if (!this.contactClientInstance) {
+      this.contactClientInstance = this.publicApiClient
+        .getContactClient()
+        .mergeHeaders(this.headers);
+    }
+
+    return this.contactClientInstance;
+  }
+
+  /**
+   * Creates a new {@link ContactClient} instance and returns it
+   * @returns {@link ContactClient}
+   */
+  public getCampaignClientInstance(): CampaignClient {
+    if (!this.campaignClientInstance) {
+      this.campaignClientInstance = this.publicApiClient
+        .getCampaignClient()
+        .mergeHeaders(this.headers);
+    }
+
+    return this.campaignClientInstance;
+  }
+
+  public getConsumptionClientInstance(): ConsumptionClient {
+    if (!this.consumptionClientInstance) {
+      this.consumptionClientInstance = this.publicApiClient
+        .getConsumptionClient()
+        .mergeHeaders(this.headers);
+    }
+
+    return this.consumptionClientInstance;
+  }
+
+  public getSecurityStandardsClientInstance(): StandardsClient {
+    if (!this.securityStandardsClientInstance) {
+      this.securityStandardsClientInstance = this.publicApiClient
+        .getSecurityStandardsClient()
+        .mergeHeaders(this.headers);
+    }
+
+    return this.securityStandardsClientInstance;
+  }
+
+  public getSecurityRegisterClientInstance(): RegisterClient {
+    if (!this.securityRegisterClientInstance) {
+      this.securityRegisterClientInstance = this.publicApiClient
+        .getSecurityRegisterClient()
+        .mergeHeaders(this.headers);
+    }
+
+    return this.securityRegisterClientInstance;
+  }
+
+  public getCartClientInstance(): CartClient {
+    if (!this.cartClientInstance) {
+      this.cartClientInstance = this.publicApiClient
+        .getCartClient()
+        .mergeHeaders(this.headers);
+    }
+
+    return this.cartClientInstance;
+  }
+  public getSupportCenterClientInstance(): SupportCenterClient {
+    if (!this.supportCenterClientInstance) {
+      this.supportCenterClientInstance = this.publicApiClient
+        .getSupportCenterClient()
+        .mergeHeaders(this.headers);
+    }
+
+    return this.supportCenterClientInstance;
+  }
+
+  public getCatalogClientInstance(): CatalogClient {
+    if (!this.catalogClientInstance) {
+      this.catalogClientInstance = this.publicApiClient
+        .getCatalogClient()
+        .mergeHeaders(this.legacyHeaders);
+    }
+
+    return this.catalogClientInstance;
+  }
+
+  public getGQLCatalogClientInstance(): CatalogGraphQLClient {
+    if (!this.gqlCatalogClientInstance) {
+      this.gqlCatalogClientInstance = this.gqlPublicApiClient
+        .getCatalogGraphQLClient()
+        .mergeHeaders(this.headers);
+    }
+
+    return this.gqlCatalogClientInstance;
+  }
+
+  public getUserClientInstance(): UserClient {
+    if (!this.userClientInstance) {
+      this.userClientInstance = this.publicApiClient
+        .getUserClient()
+        .mergeHeaders(this.headers);
+    }
+
+    return this.userClientInstance;
+  }
+
+  /**
+   * Allow to set all instances headers.
+   * @param headers
+   */
+  public mergeInstancesHeaders(headers: Record<string, string>): void {
+    this.headers = headers;
+
+    // Add here each client that need headers refresh
+    this.customerClientInstance?.mergeHeaders(headers);
+    this.whoAmIClientInstance?.mergeHeaders(headers);
+    this.checkDomainClientInstance?.mergeHeaders(headers);
+    this.subscriptionsClientInstance?.mergeHeaders(headers);
+    this.campaignClientInstance?.mergeHeaders(headers);
+    this.consumptionClientInstance?.mergeHeaders(headers);
+    this.securityStandardsClientInstance?.mergeHeaders(headers);
+    this.securityRegisterClientInstance?.mergeHeaders(headers);
+    this.cartClientInstance?.mergeHeaders(headers);
+    this.supportCenterClientInstance?.mergeHeaders(headers);
+    this.userClientInstance?.mergeHeaders(headers);
+  }
+
+  /**
+   * @deprecated
+   * @param legacyHeaders
+   */
+  public setLegacyInstancesHeaders(
+    legacyHeaders: Record<string, string>,
+  ): void {
+    this.legacyHeaders = legacyHeaders;
+
+    this.licensesClientInstance?.mergeHeaders(legacyHeaders);
+    this.catalogClientInstance?.mergeHeaders(legacyHeaders);
+  }
+}
+
+export default ClientsRegistry;

--- a/src/publicGraphQLClient.ts
+++ b/src/publicGraphQLClient.ts
@@ -3,6 +3,10 @@ import { AbstractGraphQLClient } from './abstractGraphQLClient';
 
 export class PublicGraphQLClient extends AbstractGraphQLClient {
   public getCatalogGraphQLClient(): CatalogGraphQLClient {
-    return new CatalogGraphQLClient().setUrl(this.url).setToken(this.token);
+    return new CatalogGraphQLClient()
+      .setUrl(this.url)
+      .setToken(this.token)
+      .setHeaders(this.headers)
+      .setToken(this.token);
   }
 }

--- a/tests/axiosSingleton.test.ts
+++ b/tests/axiosSingleton.test.ts
@@ -1,6 +1,6 @@
-import { AxiosSingleton } from '../build';
 import { expect } from 'chai';
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { AxiosSingleton } from '../src';
 
 const REQUEST: AxiosRequestConfig = {
   url: 'testUrl',

--- a/tests/catalog/catalogGraphQLClient.test.ts
+++ b/tests/catalog/catalogGraphQLClient.test.ts
@@ -1,8 +1,7 @@
 import nock from 'nock';
 import { expect } from 'chai';
-import { CatalogGraphQLClient } from '../../src';
+import { CatalogGraphQLClient, ProductType } from '../../src';
 import { CatalogQuery } from '../../src/catalog/types/catalogGraphQLQueries';
-import { ProductType } from '../../build';
 
 const CATALOG_GRAPHQL_URL = 'https://graphql.localhost';
 const CATALOG_POST_URL = '/catalog/graphql';
@@ -35,7 +34,7 @@ describe('CatalogGraphQLClient', () => {
       const client = new CatalogGraphQLClient()
         .setUrl(CATALOG_GRAPHQL_URL)
         .setOptions({ isAdmin: true })
-        .setOptionsHeader({ authorization: 'test' });
+        .setHeaders({ authorization: 'test' });
 
       nock(CATALOG_GRAPHQL_URL + '/admin')
         .post(CATALOG_POST_URL)
@@ -84,7 +83,7 @@ describe('CatalogGraphQLClient', () => {
     it('should return response corresponding to query', async () => {
       const client = new CatalogGraphQLClient()
         .setUrl(CATALOG_GRAPHQL_URL)
-        .setOptionsHeader({ authorization: 'test' });
+        .setHeaders({ authorization: 'test' });
 
       const products: ProductType[] = [
         {

--- a/tests/clientsRegistry.test.ts
+++ b/tests/clientsRegistry.test.ts
@@ -1,0 +1,282 @@
+import {
+  CampaignClient,
+  CartClient,
+  CatalogClient,
+  CatalogGraphQLClient,
+  CatalogQuery,
+  CheckDomainClient,
+  ConsumptionClient,
+  CustomersClient,
+  LicensesClient,
+  OrdersClient,
+  PublicApiClient,
+  RegisterClient,
+  StandardsClient,
+  SubscriptionsClient,
+  SupportCenterClient,
+  UserClient,
+  WhoAmIClient,
+} from '../src';
+import { expect } from 'chai';
+import { PublicGraphQLClient } from '../src';
+import ClientsRegistry from '../src/clientsRegistry';
+import nock from 'nock';
+import { ContactClient } from '../src/contact';
+
+describe('ClientRegistry', () => {
+  describe('Check it builds correctly each instance', () => {
+    const publicApiClient: PublicApiClient = new PublicApiClient();
+    const gqlPublicApiClient: PublicGraphQLClient = new PublicGraphQLClient();
+    const registry: ClientsRegistry = ClientsRegistry.create(
+      publicApiClient,
+      gqlPublicApiClient,
+    );
+
+    it('returns a CustomersClient', () => {
+      expect(registry.getCustomersClientInstance).to.exist;
+      const customersClient: CustomersClient = registry.getCustomersClientInstance();
+      expect(customersClient).to.be.instanceOf(CustomersClient);
+    });
+
+    it('returns a WhoAmIClient', () => {
+      expect(registry.getWhoamiClientInstance).to.exist;
+      const whoAmIClient: WhoAmIClient = registry.getWhoamiClientInstance();
+      expect(whoAmIClient).to.be.instanceOf(WhoAmIClient);
+    });
+
+    it('returns a LicensesClient', () => {
+      expect(registry.getLicensesClientInstance).to.exist;
+      const licensesClient: LicensesClient = registry.getLicensesClientInstance();
+      expect(licensesClient).to.be.instanceOf(LicensesClient);
+    });
+
+    it('returns a CheckDomainClient', () => {
+      expect(registry.getCheckDomainClientInstance).to.exist;
+      const checkDomainClient: CheckDomainClient = registry.getCheckDomainClientInstance();
+      expect(checkDomainClient).to.be.instanceOf(CheckDomainClient);
+    });
+
+    it('returns a SubscriptionsClient', () => {
+      expect(registry.getSubscriptionsClientInstance).to.exist;
+      const subscriptionsClient: SubscriptionsClient = registry.getSubscriptionsClientInstance();
+      expect(subscriptionsClient).to.be.instanceOf(SubscriptionsClient);
+    });
+
+    it('returns a OrdersClient', () => {
+      expect(registry.getOrdersClientInstance).to.exist;
+      const ordersClient: OrdersClient = registry.getOrdersClientInstance();
+      expect(ordersClient).to.be.instanceOf(OrdersClient);
+    });
+
+    it('returns a ContactClient', () => {
+      expect(registry.getContactClientInstance).to.exist;
+      const contactClient: ContactClient = registry.getContactClientInstance();
+      expect(contactClient).to.be.instanceOf(ContactClient);
+    });
+
+    it('returns a CampaignClient', () => {
+      expect(registry.getCampaignClientInstance).to.exist;
+      const campaignClient: CampaignClient = registry.getCampaignClientInstance();
+      expect(campaignClient).to.be.instanceOf(CampaignClient);
+    });
+
+    it('returns a ConsumptionClient', () => {
+      expect(registry.getConsumptionClientInstance).to.exist;
+      const campaignClient: ConsumptionClient = registry.getConsumptionClientInstance();
+      expect(campaignClient).to.be.instanceOf(ConsumptionClient);
+    });
+
+    it('returns a StandardsClient', () => {
+      expect(registry.getSecurityStandardsClientInstance).to.exist;
+      const standardsClient: StandardsClient = registry.getSecurityStandardsClientInstance();
+      expect(standardsClient).to.be.instanceOf(StandardsClient);
+    });
+
+    it('returns a RegisterClient', () => {
+      expect(registry.getSecurityStandardsClientInstance).to.exist;
+      const registerClient: RegisterClient = registry.getSecurityRegisterClientInstance();
+      expect(registerClient).to.be.instanceOf(RegisterClient);
+    });
+
+    it('returns a CartClient', () => {
+      expect(registry.getCartClientInstance).to.exist;
+      const cartClient: CartClient = registry.getCartClientInstance();
+      expect(cartClient).to.be.instanceOf(CartClient);
+    });
+
+    it('returns a SupportCenterClient', () => {
+      expect(registry.getSupportCenterClientInstance).to.exist;
+      const supportCenterClient: SupportCenterClient = registry.getSupportCenterClientInstance();
+      expect(supportCenterClient).to.be.instanceOf(SupportCenterClient);
+    });
+
+    it('returns a CatalogClient', () => {
+      expect(registry.getCatalogClientInstance).to.exist;
+      const catalogClient: CatalogClient = registry.getCatalogClientInstance();
+      expect(catalogClient).to.be.instanceOf(CatalogClient);
+    });
+
+    it('returns a CatalogGraphQLClient', () => {
+      expect(registry.getGQLCatalogClientInstance).to.exist;
+      const gqlCatalogClient: CatalogGraphQLClient = registry.getGQLCatalogClientInstance();
+      expect(gqlCatalogClient).to.be.instanceOf(CatalogGraphQLClient);
+    });
+
+    it('returns a UserClient', () => {
+      expect(registry.getUserClientInstance).to.exist;
+      const userClient: UserClient = registry.getUserClientInstance();
+      expect(userClient).to.be.instanceOf(UserClient);
+    });
+  });
+
+  describe('Check the headers are correctly merged', () => {
+    it('returns a CatalogGraphQLClient with merged headers', async () => {
+      const baseUrl = 'https://arrow.com';
+      const baseHeaders: Record<string, string> = {
+        message: 'we love potatoes',
+      };
+
+      const publicApiClient: PublicApiClient = new PublicApiClient();
+      const gqlPublicApiClient: PublicGraphQLClient = new PublicGraphQLClient()
+        .setUrl(baseUrl)
+        .setHeaders(baseHeaders);
+      const registry: ClientsRegistry = new ClientsRegistry(
+        publicApiClient,
+        gqlPublicApiClient,
+      );
+      expect(registry.getGQLCatalogClientInstance).to.exist;
+
+      const additionalHeaders: Record<string, string> = {
+        candy: 'carambar',
+      };
+      registry.mergeInstancesHeaders(additionalHeaders);
+
+      const gqlCatalogClient: CatalogGraphQLClient = registry.getGQLCatalogClientInstance();
+      expect(gqlCatalogClient).to.be.instanceOf(CatalogGraphQLClient);
+
+      const scope = nock(baseUrl)
+        .matchHeader('message', 'we love potatoes')
+        .matchHeader('candy', 'carambar')
+        .post('/catalog/graphql')
+        .reply(200, '{}');
+
+      const preparedQuery: CatalogQuery = {
+        getProducts: {
+          products: {
+            name: true,
+          },
+          __args: {
+            paginate: {
+              page: 1,
+              perPage: 12,
+            },
+            searchBody: {
+              sort: {
+                name: 'test',
+              },
+            },
+          },
+        },
+      };
+
+      await gqlCatalogClient.findByQuery(preparedQuery);
+      scope.done();
+    });
+
+    it('returns a CatalogGraphQLClient where baseHeaders has not been erased', async () => {
+      const baseUrl = 'https://arrow.com';
+      const baseHeaders: Record<string, string> = {
+        message: 'we love potatoes',
+      };
+
+      const publicApiClient: PublicApiClient = new PublicApiClient();
+      const gqlPublicApiClient: PublicGraphQLClient = new PublicGraphQLClient()
+        .setUrl(baseUrl)
+        .setHeaders(baseHeaders);
+      const registry: ClientsRegistry = new ClientsRegistry(
+        publicApiClient,
+        gqlPublicApiClient,
+      );
+      expect(registry.getGQLCatalogClientInstance).to.exist;
+
+      const gqlCatalogClient: CatalogGraphQLClient = registry.getGQLCatalogClientInstance();
+      expect(gqlCatalogClient).to.be.instanceOf(CatalogGraphQLClient);
+
+      const scope = nock(baseUrl)
+        .matchHeader('message', 'we love potatoes')
+        .post('/catalog/graphql')
+        .reply(200, '{}');
+
+      const preparedQuery: CatalogQuery = {
+        getProducts: {
+          products: {
+            name: true,
+          },
+          __args: {
+            paginate: {
+              page: 1,
+              perPage: 12,
+            },
+            searchBody: {
+              sort: {
+                name: 'test',
+              },
+            },
+          },
+        },
+      };
+
+      await gqlCatalogClient.findByQuery(preparedQuery);
+      scope.done();
+    });
+
+    it('returns a CatalogGraphQLClient without baseHeaders', async () => {
+      const baseUrl = 'https://arrow.com';
+
+      const publicApiClient: PublicApiClient = new PublicApiClient();
+      const gqlPublicApiClient: PublicGraphQLClient = new PublicGraphQLClient().setUrl(
+        baseUrl,
+      );
+      const registry: ClientsRegistry = new ClientsRegistry(
+        publicApiClient,
+        gqlPublicApiClient,
+      );
+      expect(registry.getGQLCatalogClientInstance).to.exist;
+
+      const additionalHeaders: Record<string, string> = {
+        candy: 'carambar',
+      };
+      registry.mergeInstancesHeaders(additionalHeaders);
+
+      const gqlCatalogClient: CatalogGraphQLClient = registry.getGQLCatalogClientInstance();
+      expect(gqlCatalogClient).to.be.instanceOf(CatalogGraphQLClient);
+
+      const scope = nock(baseUrl)
+        .matchHeader('candy', 'carambar')
+        .post('/catalog/graphql')
+        .reply(200, '{}');
+
+      const preparedQuery: CatalogQuery = {
+        getProducts: {
+          products: {
+            name: true,
+          },
+          __args: {
+            paginate: {
+              page: 1,
+              perPage: 12,
+            },
+            searchBody: {
+              sort: {
+                name: 'test',
+              },
+            },
+          },
+        },
+      };
+
+      await gqlCatalogClient.findByQuery(preparedQuery);
+      scope.done();
+    });
+  });
+});


### PR DESCRIPTION
In this PR:
A Http ClientsRegistry, it Resolves 2 problems:
- Allow to set headers of all registered clients if front security allows it
- Increase perf in SPA context, avoid to instanciate multiple instances for a similar http call

Uniformization of the variable headers in AbstractHttpClient, it Resolves 2 problems:
- Allow to GQL client to really customize their headers
- Allow to have same behaviour throw ClientRegistry

Method AbstractHttpClient.mergeHeaders allowing to refresh headers of client without removing the old ones.