### PR TITLE
Next jpb

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/ArrowSphere/nodejs-api-client.git"
   },
-  "version": "3.29.0",
+  "version": "3.30.0-rc-jpb.4",
   "description": "Node.js client for ArrowSphere's public API",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -16,6 +16,7 @@
     "lint:fix": "eslint ./{src,tests}/**/*.ts --fix && prettier --write ./{src,tests}/**/*.ts",
     "prepare": "npm run clean && npm run build",
     "test": "mocha -r ts-node/register \"tests/**/*.ts\"",
+    "test:one": "mocha -r ts-node/register",
     "test:watch": "mocha --watch -r ts-node/register \"tests/**/*.ts\"",
     "test:coverage": "nyc --check-coverage npm run test",
     "test:coverage:report": "nyc report --reporter=text-lcov | coveralls"

--- a/src/AbstractHttpClient.ts
+++ b/src/AbstractHttpClient.ts
@@ -9,6 +9,8 @@ export enum HttpClientSecurity {
   API_KEY = 'apikey',
 }
 
+export type Headers = Record<string, string>;
+
 export abstract class AbstractHttpClient {
   /**
    * Base path for HTTP calls
@@ -26,6 +28,10 @@ export abstract class AbstractHttpClient {
    * ArrowSphere API URL
    */
   protected url = '';
+  /**
+   * Defines header information for http requests
+   */
+  protected headers: Headers = {};
   /**
    * Http Exceptions Handlers
    */
@@ -56,11 +62,45 @@ export abstract class AbstractHttpClient {
   }
 
   /**
+   * Warning: can remove useful headers, prefer use mergeHeaders()
+   * @param headers
+   */
+  public setHeaders(headers: Record<string, string>): this {
+    this.headers = headers;
+
+    return this;
+  }
+
+  /**
+   * Will merge existing headers with those in parameters.
+   * If There is key equality, the header passed as parameter has priority.
+   * @param headers
+   */
+  public mergeHeaders(headers: Record<string, string>): this {
+    const mergedHeaders: Record<string, string> = {
+      ...this.headers,
+      ...headers,
+    };
+    this.setHeaders(mergedHeaders);
+
+    return this;
+  }
+
+  /**
    * Allow to register error/exception handler.
    * Handlers can be developed in another projects as long as they respect the interface HttpExceptionHandler.
    */
   public registerHttpExceptionHandler(handler: HttpExceptionHandler): this {
     this.httpExceptionHandlers.push(handler);
+
+    return this;
+  }
+
+  /**
+   * Allow to set error handlers.
+   */
+  public setHttpExceptionHandlers(handlers: HttpExceptionHandler[]): this {
+    this.httpExceptionHandlers = handlers;
 
     return this;
   }

--- a/src/abstractRestfulClient.ts
+++ b/src/abstractRestfulClient.ts
@@ -3,7 +3,11 @@ import querystring from 'querystring';
 import path from 'path';
 import { AxiosSingleton } from './axiosSingleton';
 import { AxiosInstance, AxiosResponse } from 'axios';
-import { AbstractHttpClient, HttpClientSecurity } from './AbstractHttpClient';
+import {
+  AbstractHttpClient,
+  Headers,
+  HttpClientSecurity,
+} from './AbstractHttpClient';
 
 /**
  * Lists of available query parameters for the API call
@@ -39,8 +43,6 @@ export type Parameters = Record<
   string | string[] | number | number[] | boolean | null | undefined
 >;
 
-export type Headers = Record<string, string>;
-
 export type Payload = Record<string, unknown> | Array<Payload>;
 
 export type Options = {
@@ -57,7 +59,7 @@ export type ExtraInformationType = {
   [ExtraInformationFields.COLUMN_EXTRA_INFORMATION]?: Record<string, unknown>;
 };
 
-export abstract class AbstractClient extends AbstractHttpClient {
+export abstract class AbstractRestfulClient extends AbstractHttpClient {
   /**
    * Axios instance for client
    */
@@ -84,13 +86,8 @@ export abstract class AbstractClient extends AbstractHttpClient {
   protected isCamelPagination = false;
 
   /**
-   * Defines header information for axios call
-   */
-  protected headers: Headers = {};
-
-  /**
    * AbstractClient constructor.
-   * @returns AbstractClient
+   * @returns AbstractRestfulClient
    */
   protected constructor(configuration?: ConfigurationsClient) {
     super();
@@ -134,21 +131,10 @@ export abstract class AbstractClient extends AbstractHttpClient {
   /**
    * Sets the page number
    * @param page - Page number
-   * @returns AbstractClient
+   * @returns AbstractRestfulClient
    */
   public setPage(page: number): this {
     this.page = page;
-
-    return this;
-  }
-
-  /**
-   * Sets Header Information
-   * @param headers - Header axios information
-   * @returns AbstractClient
-   */
-  public setHeaders(headers: Record<string, string>): this {
-    this.headers = headers;
 
     return this;
   }

--- a/src/campaign/campaignClient.ts
+++ b/src/campaign/campaignClient.ts
@@ -1,4 +1,4 @@
-import { AbstractClient, Parameters } from '../abstractClient';
+import { AbstractRestfulClient, Parameters } from '../abstractRestfulClient';
 import { GetResult } from '../getResult';
 import { Campaign } from './entities/campaign/campaign';
 import { CampaignV2 } from './entities/v2/campaign/campaign';
@@ -19,7 +19,7 @@ export type PostEmailCampaignMetadataType = {
   [keys in string]: string;
 };
 
-export class CampaignClient extends AbstractClient {
+export class CampaignClient extends AbstractRestfulClient {
   /**
    * The base path of the API
    */

--- a/src/cart/cartClient.ts
+++ b/src/cart/cartClient.ts
@@ -1,4 +1,4 @@
-import { AbstractClient, Parameters } from '../abstractClient';
+import { AbstractRestfulClient, Parameters } from '../abstractRestfulClient';
 import { GetResult } from '../getResult';
 import { Item, ItemList } from './entities';
 
@@ -35,7 +35,7 @@ export type ItemRequestType = {
 export type ItemAddRequestType = ItemRequestType;
 export type ItemUpdateRequestType = ItemRequestType;
 
-export class CartClient extends AbstractClient {
+export class CartClient extends AbstractRestfulClient {
   protected basePath = '/cart';
   public async addItem(
     postData: ItemAddRequestType,

--- a/src/catalog/catalogClient.ts
+++ b/src/catalog/catalogClient.ts
@@ -1,9 +1,9 @@
-import { AbstractClient, Parameters } from '../abstractClient';
+import { AbstractRestfulClient, Parameters } from '../abstractRestfulClient';
 import { GetResult } from '../getResult';
 import { Program } from './entities/program';
 import { Programs } from './entities/programs';
 
-export class CatalogClient extends AbstractClient {
+export class CatalogClient extends AbstractRestfulClient {
   /**
    * The base path of the API
    */

--- a/src/consumption/consumptionClient.ts
+++ b/src/consumption/consumptionClient.ts
@@ -1,9 +1,9 @@
-import { AbstractClient, Parameters } from '../abstractClient';
+import { AbstractRestfulClient, Parameters } from '../abstractRestfulClient';
 import { ConsumptionBI } from './entities/bi/consumptionBI';
 import { GetResult } from '../getResult';
 import { Consumption } from './entities/consumption/consumption';
 
-export class ConsumptionClient extends AbstractClient {
+export class ConsumptionClient extends AbstractRestfulClient {
   /**
    * The base path of the API
    */

--- a/src/contact/contactClient.ts
+++ b/src/contact/contactClient.ts
@@ -1,4 +1,4 @@
-import { AbstractClient, Parameters } from '../abstractClient';
+import { AbstractRestfulClient, Parameters } from '../abstractRestfulClient';
 import { GetData, GetResult } from '../getResult';
 import { ContactCreate } from './entities/contactCreate';
 import { Contact, ContactType } from './entities/contact';
@@ -24,7 +24,7 @@ export type ContactRequestType = {
   [ContactRequestFields.COLUMN_ROLE]: string;
 };
 
-export class ContactClient extends AbstractClient {
+export class ContactClient extends AbstractRestfulClient {
   /**
    * The base path of the API
    */

--- a/src/customers/customersClient.ts
+++ b/src/customers/customersClient.ts
@@ -1,4 +1,4 @@
-import { AbstractClient, Parameters } from '../abstractClient';
+import { AbstractRestfulClient, Parameters } from '../abstractRestfulClient';
 import { GetResult } from '../getResult';
 import { DataCustomers } from './entities/dataCustomers';
 import { DataInvitation } from './entities/dataInvitation';
@@ -34,7 +34,7 @@ export type PatchCustomerContactPayload = {
   [Property in keyof PostCustomerContactPayload]?: PostCustomerContactPayload[Property];
 };
 
-export class CustomersClient extends AbstractClient {
+export class CustomersClient extends AbstractRestfulClient {
   /**
    * The base path of the API
    */

--- a/src/general/checkDomainClient.ts
+++ b/src/general/checkDomainClient.ts
@@ -1,12 +1,12 @@
 import { AxiosResponse } from 'axios';
-import { AbstractClient, Parameters } from '../abstractClient';
+import { AbstractRestfulClient, Parameters } from '../abstractRestfulClient';
 
 export type CheckDomainData = { isDomainAvailable: boolean };
 
 /**
  * Class CheckDomainClient
  */
-export class CheckDomainClient extends AbstractClient {
+export class CheckDomainClient extends AbstractRestfulClient {
   /**
    * @param vendorName - The vendor's name
    * @param domainName - The domain to check

--- a/src/general/whoAmIClient.ts
+++ b/src/general/whoAmIClient.ts
@@ -1,8 +1,8 @@
-import { AbstractClient } from '../abstractClient';
+import { AbstractRestfulClient } from '../abstractRestfulClient';
 import { AxiosResponse } from 'axios';
 import { WhoAmI, WhoAmIResponseData } from './entities/whoAmI';
 
-export class WhoAmIClient extends AbstractClient {
+export class WhoAmIClient extends AbstractRestfulClient {
   /**
    * Gets and returns the raw whoami call response data
    * @returns Promise\<AxiosResponse\<{@link WhoAmIResponseData}\>\>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * from './axiosSingleton';
-export * from './abstractClient';
+export * from './abstractRestfulClient';
 export * from './abstractEntity';
 export * from './abstractGraphQLClient';
 export * from './campaign/';
@@ -20,5 +20,6 @@ export * from './security/';
 export * from './subscriptions/';
 export * from './supportCenter/';
 export * from './securityScore/';
+export * from './user/';
 export { ContactInformation };
 import * as ContactInformation from './contact';

--- a/src/licenses/entities/findResult.ts
+++ b/src/licenses/entities/findResult.ts
@@ -6,7 +6,7 @@ import { FilterFindResult, FilterFindResultData } from './filterFindResult';
 import { AbstractEntity } from '../../abstractEntity';
 import { LicensesClient, LicenseFindRawPayload } from '../licensesClient';
 import { OfferFindResult, OfferFindResultData } from './offer/offerFindResult';
-import { Parameters } from '../../abstractClient';
+import { Parameters } from '../../abstractRestfulClient';
 
 export type FindData = {
   pagination: {

--- a/src/licenses/licensesClient.ts
+++ b/src/licenses/licensesClient.ts
@@ -2,10 +2,10 @@
  * Class LicensesClient
  */
 import {
-  AbstractClient,
+  AbstractRestfulClient,
   ExtraInformationType,
   Parameters,
-} from '../abstractClient';
+} from '../abstractRestfulClient';
 import { FindConfig, FindData, FindResult } from './entities/findResult';
 import {
   ConfigFindResult,
@@ -308,7 +308,7 @@ export type PutCancelAutoRenew = ExtraInformationType;
 
 export type PutReactivateAutoRenew = ExtraInformationType;
 
-export class LicensesClient extends AbstractClient {
+export class LicensesClient extends AbstractRestfulClient {
   /**
    * The base path of the API
    */

--- a/src/orders/ordersClient.ts
+++ b/src/orders/ordersClient.ts
@@ -1,4 +1,4 @@
-import { AbstractClient, Parameters } from '../abstractClient';
+import { AbstractRestfulClient, Parameters } from '../abstractRestfulClient';
 import { GetResult } from '../getResult';
 import { DataListOrders } from './entities/dataListOrders';
 import { ReferenceLink } from './entities/referenceLink';
@@ -95,7 +95,7 @@ export type CreateOrderInputType = {
   }>;
 };
 
-export class OrdersClient extends AbstractClient {
+export class OrdersClient extends AbstractRestfulClient {
   /**
    * The base path of the API
    */

--- a/src/publicApiClient.ts
+++ b/src/publicApiClient.ts
@@ -1,4 +1,4 @@
-import { AbstractClient } from './abstractClient';
+import { AbstractRestfulClient } from './abstractRestfulClient';
 import { CheckDomainClient, WhoAmIClient } from './general';
 import { LicensesClient } from './licenses';
 import { SubscriptionsClient } from './subscriptions';
@@ -12,11 +12,12 @@ import { RegisterClient } from './security';
 import { CartClient } from './cart/cartClient';
 import { SupportCenterClient } from './supportCenter';
 import { CatalogClient } from './catalog';
+import { UserClient } from './user';
 
 /**
  * Public API Client class, should be the main entry point for your calls
  */
-export class PublicApiClient extends AbstractClient {
+export class PublicApiClient extends AbstractRestfulClient {
   constructor() {
     super();
   }
@@ -29,7 +30,8 @@ export class PublicApiClient extends AbstractClient {
     return new CustomersClient()
       .setUrl(this.url)
       .setApiKey(this.apiKey)
-      .setHeaders(this.headers);
+      .setHeaders(this.headers)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
   }
 
   /**
@@ -40,7 +42,8 @@ export class PublicApiClient extends AbstractClient {
     return new WhoAmIClient()
       .setUrl(this.url)
       .setApiKey(this.apiKey)
-      .setHeaders(this.headers);
+      .setHeaders(this.headers)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
   }
 
   /**
@@ -51,7 +54,8 @@ export class PublicApiClient extends AbstractClient {
     return new LicensesClient()
       .setUrl(this.url)
       .setApiKey(this.apiKey)
-      .setHeaders(this.headers);
+      .setHeaders(this.headers)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
   }
 
   /**
@@ -62,7 +66,8 @@ export class PublicApiClient extends AbstractClient {
     return new CheckDomainClient()
       .setUrl(this.url)
       .setApiKey(this.apiKey)
-      .setHeaders(this.headers);
+      .setHeaders(this.headers)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
   }
 
   /**
@@ -73,7 +78,8 @@ export class PublicApiClient extends AbstractClient {
     return new SubscriptionsClient()
       .setUrl(this.url)
       .setApiKey(this.apiKey)
-      .setHeaders(this.headers);
+      .setHeaders(this.headers)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
   }
 
   /**
@@ -84,7 +90,8 @@ export class PublicApiClient extends AbstractClient {
     return new OrdersClient()
       .setUrl(this.url)
       .setApiKey(this.apiKey)
-      .setHeaders(this.headers);
+      .setHeaders(this.headers)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
   }
 
   /**
@@ -95,7 +102,8 @@ export class PublicApiClient extends AbstractClient {
     return new ContactClient()
       .setUrl(this.url)
       .setApiKey(this.apiKey)
-      .setHeaders(this.headers);
+      .setHeaders(this.headers)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
   }
 
   /**
@@ -106,48 +114,63 @@ export class PublicApiClient extends AbstractClient {
     return new CampaignClient()
       .setUrl(this.url)
       .setApiKey(this.apiKey)
-      .setHeaders(this.headers);
+      .setHeaders(this.headers)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
   }
 
   public getConsumptionClient(): ConsumptionClient {
     return new ConsumptionClient()
       .setUrl(this.url)
       .setApiKey(this.apiKey)
-      .setHeaders(this.headers);
+      .setHeaders(this.headers)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
   }
 
   public getSecurityStandardsClient(): StandardsClient {
     return new StandardsClient()
       .setUrl(this.url)
       .setApiKey(this.apiKey)
-      .setHeaders(this.headers);
+      .setHeaders(this.headers)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
   }
 
   public getSecurityRegisterClient(): RegisterClient {
     return new RegisterClient()
       .setUrl(this.url)
       .setApiKey(this.apiKey)
-      .setHeaders(this.headers);
+      .setHeaders(this.headers)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
   }
 
   public getCartClient(): CartClient {
     return new CartClient()
       .setUrl(this.url)
       .setApiKey(this.apiKey)
-      .setHeaders(this.headers);
+      .setHeaders(this.headers)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
   }
   public getSupportCenterClient(): SupportCenterClient {
     return new SupportCenterClient()
       .setUrl(this.url)
       .setApiKey(this.apiKey)
-      .setHeaders(this.headers);
+      .setHeaders(this.headers)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
   }
 
   public getCatalogClient(): CatalogClient {
     return new CatalogClient()
       .setUrl(this.url)
       .setApiKey(this.apiKey)
-      .setHeaders(this.headers);
+      .setHeaders(this.headers)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
+  }
+
+  public getUserClient(): UserClient {
+    return new UserClient()
+      .setUrl(this.url)
+      .setApiKey(this.apiKey)
+      .setHeaders(this.headers)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
   }
 }
 

--- a/src/publicGraphQLClient.ts
+++ b/src/publicGraphQLClient.ts
@@ -3,6 +3,11 @@ import { AbstractGraphQLClient } from './abstractGraphQLClient';
 
 export class PublicGraphQLClient extends AbstractGraphQLClient {
   public getCatalogGraphQLClient(): CatalogGraphQLClient {
-    return new CatalogGraphQLClient().setUrl(this.url).setToken(this.token);
+    return new CatalogGraphQLClient()
+      .setUrl(this.url)
+      .setToken(this.token)
+      .setHeaders(this.headers)
+      .setToken(this.token)
+      .setHttpExceptionHandlers(this.httpExceptionHandlers);
   }
 }

--- a/src/security/register/registerClient.ts
+++ b/src/security/register/registerClient.ts
@@ -1,8 +1,8 @@
-import { AbstractClient, Parameters } from '../../abstractClient';
+import { AbstractRestfulClient, Parameters } from '../../abstractRestfulClient';
 import { GetResult } from '../../getResult';
 import { RegistrationLink } from './entity/registrationLink';
 
-export class RegisterClient extends AbstractClient {
+export class RegisterClient extends AbstractRestfulClient {
   /**
    * The base path of the API
    */

--- a/src/security/standards/standardsClient.ts
+++ b/src/security/standards/standardsClient.ts
@@ -1,10 +1,10 @@
-import { AbstractClient, Parameters } from '../../abstractClient';
+import { AbstractRestfulClient, Parameters } from '../../abstractRestfulClient';
 import { Standards } from './entities/standards/standards';
 import { GetResult } from '../../getResult';
 import { Checks } from './entities/checks/checks';
 import { Resources } from './entities/resources/resources';
 
-export class StandardsClient extends AbstractClient {
+export class StandardsClient extends AbstractRestfulClient {
   /**
    * The base path of the API
    */

--- a/src/subscriptions/subscriptionsClient.ts
+++ b/src/subscriptions/subscriptionsClient.ts
@@ -1,7 +1,7 @@
 /**
  * Class SubscriptionsClient
  */
-import { AbstractClient } from '../abstractClient';
+import { AbstractRestfulClient } from '../abstractRestfulClient';
 import { SubscriptionData } from './entities/subscription';
 import { SubscriptionsListResult } from './entities/subscriptionsListResult';
 
@@ -32,7 +32,7 @@ export type SubscriptionsListData = {
   };
 };
 
-export class SubscriptionsClient extends AbstractClient {
+export class SubscriptionsClient extends AbstractRestfulClient {
   /**
    * The base path of the API
    */

--- a/src/supportCenter/payloads/issue.ts
+++ b/src/supportCenter/payloads/issue.ts
@@ -5,7 +5,7 @@ import {
   IssueOfferType,
   IssueStatusesType,
 } from '../entities/issue/issue';
-import { Payload } from '../../abstractClient';
+import { Payload } from '../../abstractRestfulClient';
 
 export enum IssueProgramsType {
   MSCSP = 'MSCSP',

--- a/src/supportCenter/supportCenterClient.ts
+++ b/src/supportCenter/supportCenterClient.ts
@@ -1,8 +1,8 @@
 import {
-  AbstractClient,
+  AbstractRestfulClient,
   Parameters,
   ParametersWithPaginationType,
-} from '../abstractClient';
+} from '../abstractRestfulClient';
 import { Issue, Issues, IssueStatusesType } from './entities/issue/issue';
 import { GetResult } from '../getResult';
 import { IssueAttachment, IssueAttachments } from './entities/issue/attachment';
@@ -34,7 +34,7 @@ export type ListIssueParametersType = ParametersWithPaginationType & {
   [ListIssueParametersFields.TITLE]?: string;
 };
 
-export class SupportCenterClient extends AbstractClient {
+export class SupportCenterClient extends AbstractRestfulClient {
   protected basePath = '/support';
 
   public async listTopics(

--- a/src/user/UserClient.ts
+++ b/src/user/UserClient.ts
@@ -1,0 +1,16 @@
+import { AbstractRestfulClient, Parameters } from '../abstractRestfulClient';
+import { CompleteWhoAmI } from './types';
+import { GetResult } from '../getResult';
+
+export class UserClient extends AbstractRestfulClient {
+  protected basePath = '/partners/users/rights';
+
+  /**
+   * To get the infos and rights about a user.
+   */
+  public async getInfos(
+    parameters: Parameters = {},
+  ): Promise<GetResult<CompleteWhoAmI>> {
+    return new GetResult(CompleteWhoAmI, await this.get(parameters));
+  }
+}

--- a/src/user/index.ts
+++ b/src/user/index.ts
@@ -1,0 +1,2 @@
+export * from './UserClient';
+export * from './types';

--- a/src/user/types/CompleteWhoAmI.ts
+++ b/src/user/types/CompleteWhoAmI.ts
@@ -1,0 +1,50 @@
+import { AbstractEntity } from '../../abstractEntity';
+import {
+  CompleteWhoAmICompany,
+  CompleteWhoAmICompanyData,
+} from './CompleteWhoAmICompany';
+import {
+  CompleteWhoAmIUser,
+  CompleteWhoAmIUserData,
+} from './CompleteWhoAmIUser';
+
+export enum CompleteWhoAmIResponseFields {
+  COLUMN_COMPANY = 'company',
+  COLUMN_USER = 'user',
+}
+
+export type CompleteWhoAmIResponseData = {
+  [CompleteWhoAmIResponseFields.COLUMN_COMPANY]: CompleteWhoAmICompanyData;
+  [CompleteWhoAmIResponseFields.COLUMN_USER]: CompleteWhoAmIUserData;
+};
+
+export class CompleteWhoAmI extends AbstractEntity<CompleteWhoAmIResponseData> {
+  constructor(data: CompleteWhoAmIResponseData) {
+    super(data);
+
+    this.#user = new CompleteWhoAmIUser(
+      data[CompleteWhoAmIResponseFields.COLUMN_USER],
+    );
+    this.#company = new CompleteWhoAmICompany(
+      data[CompleteWhoAmIResponseFields.COLUMN_COMPANY],
+    );
+  }
+
+  readonly #user: CompleteWhoAmIUser;
+  readonly #company: CompleteWhoAmICompany;
+
+  get user(): CompleteWhoAmIUser {
+    return this.#user;
+  }
+
+  get company(): CompleteWhoAmICompany {
+    return this.#company;
+  }
+
+  public toJSON(): CompleteWhoAmIResponseData {
+    return {
+      [CompleteWhoAmIResponseFields.COLUMN_USER]: this.user.toJSON(),
+      [CompleteWhoAmIResponseFields.COLUMN_COMPANY]: this.company.toJSON(),
+    };
+  }
+}

--- a/src/user/types/CompleteWhoAmICompany.ts
+++ b/src/user/types/CompleteWhoAmICompany.ts
@@ -1,0 +1,76 @@
+import { AbstractEntity } from '../../abstractEntity';
+
+export enum CompleteWhoAmICompanyFields {
+  COLUMN_HAS_ACCESS_TO_XCP = 'hasAccessToXcp',
+  COLUMN_IS_PROTECTED = 'isProtected',
+  COLUMN_MARKETPLACE = 'marketplace',
+  COLUMN_NAME = 'name',
+  COLUMN_REFERENCE = 'reference',
+  COLUMN_TAGS = 'tags',
+}
+
+export type CompleteWhoAmICompanyData = {
+  [CompleteWhoAmICompanyFields.COLUMN_HAS_ACCESS_TO_XCP]: boolean;
+  [CompleteWhoAmICompanyFields.COLUMN_IS_PROTECTED]: boolean;
+  [CompleteWhoAmICompanyFields.COLUMN_MARKETPLACE]?: string;
+  [CompleteWhoAmICompanyFields.COLUMN_NAME]?: string;
+  [CompleteWhoAmICompanyFields.COLUMN_REFERENCE]: string;
+  [CompleteWhoAmICompanyFields.COLUMN_TAGS]: string[];
+};
+
+export class CompleteWhoAmICompany extends AbstractEntity<CompleteWhoAmICompanyData> {
+  constructor(data: CompleteWhoAmICompanyData) {
+    super(data);
+
+    this.#hasAccessToXcp =
+      data[CompleteWhoAmICompanyFields.COLUMN_HAS_ACCESS_TO_XCP];
+    this.#isProtected = data[CompleteWhoAmICompanyFields.COLUMN_IS_PROTECTED];
+    this.#marketplace = data[CompleteWhoAmICompanyFields.COLUMN_MARKETPLACE];
+    this.#name = data[CompleteWhoAmICompanyFields.COLUMN_NAME];
+    this.#reference = data[CompleteWhoAmICompanyFields.COLUMN_REFERENCE];
+    this.#tags = data[CompleteWhoAmICompanyFields.COLUMN_TAGS];
+  }
+
+  readonly #hasAccessToXcp: boolean;
+  readonly #isProtected: boolean;
+  readonly #marketplace?: string;
+  readonly #name?: string;
+  readonly #reference: string;
+  readonly #tags: string[];
+
+  get hasAccessToXcp(): boolean {
+    return this.#hasAccessToXcp;
+  }
+
+  get isProtected(): boolean {
+    return this.#isProtected;
+  }
+
+  get marketplace(): string | undefined {
+    return this.#marketplace;
+  }
+
+  get name(): string | undefined {
+    return this.#name;
+  }
+
+  get reference(): string {
+    return this.#reference;
+  }
+
+  get tags(): string[] {
+    return this.#tags;
+  }
+
+  public toJSON(): CompleteWhoAmICompanyData {
+    return {
+      [CompleteWhoAmICompanyFields.COLUMN_HAS_ACCESS_TO_XCP]: this
+        .hasAccessToXcp,
+      [CompleteWhoAmICompanyFields.COLUMN_IS_PROTECTED]: this.isProtected,
+      [CompleteWhoAmICompanyFields.COLUMN_MARKETPLACE]: this.marketplace,
+      [CompleteWhoAmICompanyFields.COLUMN_NAME]: this.name,
+      [CompleteWhoAmICompanyFields.COLUMN_REFERENCE]: this.reference,
+      [CompleteWhoAmICompanyFields.COLUMN_TAGS]: this.tags,
+    };
+  }
+}

--- a/src/user/types/CompleteWhoAmIUser.ts
+++ b/src/user/types/CompleteWhoAmIUser.ts
@@ -1,0 +1,101 @@
+import { AbstractEntity } from '../../abstractEntity';
+
+export enum CompleteWhoAmIUserFields {
+  COLUMN_EMAIL = 'email',
+  COLUMN_FIRSTNAME = 'firstname',
+  COLUMN_LASTNAME = 'lastname',
+  COLUMN_LOGIN = 'login',
+  COLUMN_POLICIES = 'policies',
+  COLUMN_REFERENCE = 'reference',
+  COLUMN_RIGHTS = 'rights',
+  COLUMN_SCOPES = 'scopes',
+  COLUMN_XAP_USERNAME = 'xapUsername',
+}
+
+export type CompleteWhoAmIUserData = {
+  [CompleteWhoAmIUserFields.COLUMN_EMAIL]?: string;
+  [CompleteWhoAmIUserFields.COLUMN_FIRSTNAME]?: string;
+  [CompleteWhoAmIUserFields.COLUMN_LASTNAME]?: string;
+  [CompleteWhoAmIUserFields.COLUMN_LOGIN]?: string;
+  [CompleteWhoAmIUserFields.COLUMN_POLICIES]: string[];
+  [CompleteWhoAmIUserFields.COLUMN_REFERENCE]: string;
+  [CompleteWhoAmIUserFields.COLUMN_RIGHTS]: string[];
+  [CompleteWhoAmIUserFields.COLUMN_SCOPES]: string[];
+  [CompleteWhoAmIUserFields.COLUMN_XAP_USERNAME]: string;
+};
+
+export class CompleteWhoAmIUser extends AbstractEntity<CompleteWhoAmIUserData> {
+  constructor(data: CompleteWhoAmIUserData) {
+    super(data);
+
+    this.#email = data[CompleteWhoAmIUserFields.COLUMN_EMAIL];
+    this.#firstname = data[CompleteWhoAmIUserFields.COLUMN_FIRSTNAME];
+    this.#lastname = data[CompleteWhoAmIUserFields.COLUMN_LASTNAME];
+    this.#login = data[CompleteWhoAmIUserFields.COLUMN_LOGIN];
+    this.#policies = data[CompleteWhoAmIUserFields.COLUMN_POLICIES];
+    this.#reference = data[CompleteWhoAmIUserFields.COLUMN_REFERENCE];
+    this.#rights = data[CompleteWhoAmIUserFields.COLUMN_RIGHTS];
+    this.#scopes = data[CompleteWhoAmIUserFields.COLUMN_SCOPES];
+    this.#xapUsername = data[CompleteWhoAmIUserFields.COLUMN_XAP_USERNAME];
+  }
+
+  readonly #email?: string;
+  readonly #firstname?: string;
+  readonly #lastname?: string;
+  readonly #login?: string;
+  readonly #policies: string[];
+  readonly #reference: string;
+  readonly #rights: string[];
+  readonly #scopes: string[];
+  readonly #xapUsername: string;
+
+  get email(): string | undefined {
+    return this.#email;
+  }
+
+  get firstname(): string | undefined {
+    return this.#firstname;
+  }
+
+  get lastname(): string | undefined {
+    return this.#lastname;
+  }
+
+  get login(): string | undefined {
+    return this.#login;
+  }
+
+  get policies(): string[] {
+    return this.#policies;
+  }
+
+  get reference(): string {
+    return this.#reference;
+  }
+
+  get rights(): string[] {
+    return this.#rights;
+  }
+
+  get scopes(): string[] {
+    return this.#scopes;
+  }
+
+  get xapUsername(): string {
+    return this.#xapUsername;
+  }
+
+  public toJSON(): CompleteWhoAmIUserData {
+    return {
+      [CompleteWhoAmIUserFields.COLUMN_EMAIL]: this.email,
+      [CompleteWhoAmIUserFields.COLUMN_FIRSTNAME]: this.firstname,
+      [CompleteWhoAmIUserFields.COLUMN_LASTNAME]: this.lastname,
+      [CompleteWhoAmIUserFields.COLUMN_LOGIN]: this.login,
+      [CompleteWhoAmIUserFields.COLUMN_POLICIES]: this.policies,
+      [CompleteWhoAmIUserFields.COLUMN_REFERENCE]: this.reference,
+      [CompleteWhoAmIUserFields.COLUMN_RIGHTS]: this.rights,
+      [CompleteWhoAmIUserFields.COLUMN_SCOPES]: this.scopes,
+      [CompleteWhoAmIUserFields.COLUMN_XAP_USERNAME]: this.xapUsername,
+    };
+  }
+}

--- a/src/user/types/index.ts
+++ b/src/user/types/index.ts
@@ -1,0 +1,3 @@
+export * from './CompleteWhoAmI';
+export * from './CompleteWhoAmICompany';
+export * from './CompleteWhoAmIUser';

--- a/tests/TestClient.ts
+++ b/tests/TestClient.ts
@@ -1,4 +1,4 @@
-import { AbstractClient, ConfigurationsClient } from '../src';
+import { AbstractRestfulClient, ConfigurationsClient } from '../src';
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { URL, URLSearchParams } from 'url';
 
@@ -10,7 +10,7 @@ export type ExpectFunctionParameters = {
 export const MOCK_URL = 'https://localhost';
 export const TEST_ENDPOINT = '/test';
 
-export class TestClient extends AbstractClient {
+export class TestClient extends AbstractRestfulClient {
   constructor(configuration?: ConfigurationsClient) {
     super(configuration);
   }

--- a/tests/abstractClient.test.ts
+++ b/tests/abstractClient.test.ts
@@ -6,7 +6,7 @@ import nock from 'nock';
 
 // Sources
 import {
-  AbstractClient,
+  AbstractRestfulClient,
   ConfigurationsClient,
   NotFoundException,
   ParameterKeys,
@@ -51,7 +51,7 @@ describe('AbstractClient', () => {
         },
       };
       const client = new TestClient(configurations);
-      expect(client).to.be.an.instanceof(AbstractClient);
+      expect(client).to.be.an.instanceof(AbstractRestfulClient);
       expect(client['url']).to.be.equal(configurations[ParameterKeys.URL]);
       expect(client['apiKey']).to.be.equal(
         configurations[ParameterKeys.API_KEY],

--- a/tests/axiosSingleton.test.ts
+++ b/tests/axiosSingleton.test.ts
@@ -1,6 +1,6 @@
-import { AxiosSingleton } from '../build';
 import { expect } from 'chai';
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { AxiosSingleton } from '../src';
 
 const REQUEST: AxiosRequestConfig = {
   url: 'testUrl',

--- a/tests/catalog/catalogGraphQLClient.test.ts
+++ b/tests/catalog/catalogGraphQLClient.test.ts
@@ -1,8 +1,7 @@
 import nock from 'nock';
 import { expect } from 'chai';
-import { CatalogGraphQLClient } from '../../src';
+import { CatalogGraphQLClient, ProductType } from '../../src';
 import { CatalogQuery } from '../../src/catalog/types/catalogGraphQLQueries';
-import { ProductType } from '../../build';
 
 const CATALOG_GRAPHQL_URL = 'https://graphql.localhost';
 const CATALOG_POST_URL = '/catalog/graphql';
@@ -35,7 +34,7 @@ describe('CatalogGraphQLClient', () => {
       const client = new CatalogGraphQLClient()
         .setUrl(CATALOG_GRAPHQL_URL)
         .setOptions({ isAdmin: true })
-        .setOptionsHeader({ authorization: 'test' });
+        .setHeaders({ authorization: 'test' });
 
       nock(CATALOG_GRAPHQL_URL + '/admin')
         .post(CATALOG_POST_URL)
@@ -84,7 +83,7 @@ describe('CatalogGraphQLClient', () => {
     it('should return response corresponding to query', async () => {
       const client = new CatalogGraphQLClient()
         .setUrl(CATALOG_GRAPHQL_URL)
-        .setOptionsHeader({ authorization: 'test' });
+        .setHeaders({ authorization: 'test' });
 
       const products: ProductType[] = [
         {


### PR DESCRIPTION
Renaming of AbstractRestfulClient
add UserClient to PublicApiClient
Allow to mergeHeaders instead of setHeaders (dangerous can remove headers)
Allow to propagate easily an error handler from PublicApiClient to its instances
