### PR TITLE
fix last release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.367.1] - 2026.05.12
+### Added
+- [Task] fix last release
+
 ## [3.367.0] - 2026.05.11
 ### Added
 - [ItemData] Add field `attributesParameters` in itemData for quote & order

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/ArrowSphere/nodejs-api-client.git"
   },
-  "version": "3.367.0",
+  "version": "3.367.1",
   "description": "Node.js client for ArrowSphere's public API",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
It appears that my previous release 3.367.0 has taken the code of the 3.366.0, maybe because the merge took too much time. 